### PR TITLE
Added std namespace to 'maths.h'

### DIFF
--- a/source/maths.h
+++ b/source/maths.h
@@ -13,6 +13,8 @@
 
 #include <cmath>
 
+using namespace std;
+
 // Math types
 
 struct float2


### PR DESCRIPTION
This is my first contribution to git repository, so forgive any courtesies or standards that have been missed. I just was having compilation errors due to the namespace used by <cmath> not being added to any functions/methods, and no namespaces declared. Please ignore this contribution if it misses something, and I am eager to learn of any mistakes I have made when trying to contribute.

Also, I have noticed that SDL2 is required, but the default compilation of the SDL repository results in SDL3. So SDL must be manually requested with explicit instructions for SDL2 before this program will be compiled (git clone {SDL repo.} -b sdl2). This might be a given though so I didn't make any changes to the CMakeLists.txt.